### PR TITLE
Expand code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,17 @@ Failing to follow the community guidelines as described in this document carries
 
 ## Slack Etiquette
 
-### Slack Commands
 
 Many members of AAC have this Slack open during the work day, or installed on their phones. Additionally, there are members in many different time zones. As such, all mass ping notifications (`@here` and `@all`) have been disabled.
 
 For tips and tricks or questions about Slack usage, check out #meta.
 
 ### Best Practices
+
 * Stay on topic. The goal of the AAC Slack is to facilitate discussion of things relating to Android development. This could be about marketing, business, server-side programming, or other things that may be important to an Android developer. For off-topic topics go to #random
-* If you have a technical question, please try and figure it out before posting here. If you're having trouble, all questions are welcome.
+* If you're having trouble, all questions are welcome.  However, make sure to value your fellow members' time, and be considerate when asking questions. Before asking a question, please Google for it, and consult the Android documentation. If it is still unclear, please reference the sources you consulted in your question.  
 * Before asking any questions, please check if there's a channel for it before asking in #general-talk
+* When answering questions, avoid condescending language or impatience. We are all trying our hardest! 
 * Job posting can be posted in #hiring only. Do not reach out to individuals for hiring purposes.
 
-### Q & A
 
-Value your fellow members' time, and be considerate when asking questions. Before asking a question, please Google for it, and consult the Android documentation. If it is still unclear, please reference the sources you consulted in your question.
-
-When answering questions, avoid condescending language or impatience. We are all trying our hardest! 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 This code of conduct applies to:
 
-* all Atlanta Android Club events
+* any and all events hosted or organized by Atlanta Android Club
 * the Atlanta Android Club Slack
-* any and all things hosted or organized by Atlanta Android Club
 
 In addition to this document, also read our read our [Anti-Harassment Policy](anti-harrasment-policy.md).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 ## Code of Conduct
 
-### The **Atlanta Android Club (AAC) Slack** should be a safe place for everybody regardless of
+This code of conduct applies to:
+
+* all Atlanta Android Club events
+* the Atlanta Android Club Slack
+* any and all things hosted or organized by Atlanta Android Club
+
+In addition to this document, also read our read our [Anti-Harassment Policy](anti-harrasment-policy.md).
+
+### The **Atlanta Android Club (AAC)** should be a safe place for everybody regardless of
 
 - gender, gender identity or gender expression 
 - sexual orientation
@@ -12,10 +20,10 @@
 - age
 - religion
 
-### As someone who is part of this Slack, you agree that:
+### As someone who is part of AAC, you agree that:
 
 * We are collectively and individually committed to safety and inclusivity.
-* We have zero tolerance for abuse, harassment, or discrimination.
+* We have zero tolerance for abuse, harassment (see our [Anti-Harassment Policy](anti-harrasment-policy.md)), or discrimination.  
 * We respect people’s boundaries and identities.
 * We refrain from using language that can be considered oppressive (systemically or otherwise), eg. sexist, racist, homophobic, transphobic, ableist, classist, etc. - this includes (but is not limited to) various slurs.
 * We avoid using offensive topics as a form of humor.
@@ -42,17 +50,11 @@
 * Ask for tips / help with avoiding making the offense in the future.
 * Apologize and ask forgiveness.
 
-Failing to follow the community guidelines as described in this document carries consequences. For minor infractions, you may be temporarily suspended from the Slack. Upon repeat offenses, or if the community believes you are not acting in good faith, you may be asked to leave permanently.
+Failing to follow the community guidelines as described in this document carries consequences. For minor infractions, you may be temporarily suspended from events or the Slack. Upon repeat offenses, or if the community believes you are not acting in good faith, you may be asked to leave permanently.
 
 ### Privacy
 * All conversations are private unless otherwise specified. 
 * If you wish to share a conversation, or part of one, you must get permission from each person involved.
-
-### Best Practices
-* Stay on topic. The goal of the AAC Slack is to facilitate discussion of things relating to Android development. This could be about marketing, business, server-side programming, or other things that may be important to an Android developer. For off-topic topics go to #random
-* If you have a technical question, please try and figure it out before posting here. If you're having trouble, all questions are welcome.
-* Before asking any questions, please check if there's a channel for it before asking in #general-talk
-* Job posting can be posted in #hiring only. Do not reach out to individuals for hiring purposes.
 
 **If you experience abuse, harassment, discrimination, or feel unsafe, let a moderator know. Here is a list of the current admins:**
 
@@ -73,6 +75,12 @@ Failing to follow the community guidelines as described in this document carries
 Many members of AAC have this Slack open during the work day, or installed on their phones. Additionally, there are members in many different time zones. As such, all mass ping notifications (`@here` and `@all`) have been disabled.
 
 For tips and tricks or questions about Slack usage, check out #meta.
+
+### Best Practices
+* Stay on topic. The goal of the AAC Slack is to facilitate discussion of things relating to Android development. This could be about marketing, business, server-side programming, or other things that may be important to an Android developer. For off-topic topics go to #random
+* If you have a technical question, please try and figure it out before posting here. If you're having trouble, all questions are welcome.
+* Before asking any questions, please check if there's a channel for it before asking in #general-talk
+* Job posting can be posted in #hiring only. Do not reach out to individuals for hiring purposes.
 
 ### Q & A
 

--- a/anti-harrasment-policy.md
+++ b/anti-harrasment-policy.md
@@ -1,0 +1,71 @@
+# Anti-Harassment Policy (template)
+
+Why do we have an official anti-harassment policy for GDG [chapter] / Community Group events?
+
+It sets expectations for behavior at the event. Simply having an anti-harassment policy can prevent harassment.
+It encourages people to attend who have had bad experiences at other events.
+It gives event staff/volunteers instructions on how to handle harassment quickly, with the minimum amount of disruption for the event.
+GDG [chapter] / Community Group is dedicated to providing a harassment-free event experience for everyone, regardless of:
+
+* gender
+* sexual orientation
+* disability
+* gender identity
+* age
+* race
+* religion
+* nationality
+
+The above is not an exhaustive list -- we do not tolerate harassment of event 
+participants in any form.
+
+Sexual language and imagery is not appropriate for any event venue, including 
+talks. Event participants violating these rules may be expelled from the event, 
+and even banned from future events at the discretion of the event 
+organizers/management.
+
+Harassment includes (but is not limited to):
+
+* offensive verbal comments related to gender, sexual orientation, disability, gender identity, age, race, religion
+* the use or display of sexual images in public spaces
+* deliberate intimidation
+* stalking
+* harassing photography or recording
+* sustained disruption of talks or other events
+* inappropriate physical contact
+* unwelcome sexual attention
+
+​​​Participants asked to stop any harassing behavior are expected to comply 
+immediately.
+
+Exhibiting partners and guest speakers are also subject to the anti-harassment 
+policy. In particular, exhibitors and speakers should not use sexualized 
+images, activities, or other material, or otherwise create a sexualized 
+environment in their slide decks, exhibit material, exhibit staffing, 
+promotional items or demo material.
+
+If you are being harassed, notice that someone else is being harassed, or have 
+any other concerns, please contact an organizer or event volunteer immediately. 
+Organizers and event volunteers may be identified by t-shirts or special 
+badges/lanyards. Organizers will investigate the issue and take appropriate 
+action. This may include helping participants contact venue security or local 
+law enforcement, provide escorts, or otherwise assist those experiencing 
+harassment to feel safe for the duration of the event.
+
+Contacts:
+
+[Email address for organizers]
+[Phone number for organizers]
+[Phone number for event security]
+[Local law enforcement]
+[Local emergency and non-emergency medical]
+[Local taxi company]
+
+Though we hope that we never have to invoke this policy, we believe that having 
+this document helps everyone think a little more about how their actions and 
+words affect the whole community, as well as individuals in the community.
+
+## License and attribution
+
+This policy is licensed under the Creative Commons Zero license. This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.
+

--- a/anti-harrasment-policy.md
+++ b/anti-harrasment-policy.md
@@ -1,4 +1,4 @@
-# Anti-Harassment Policy (template)
+# Anti-Harassment Policy
 
 Why do we have an official anti-harassment policy for Atlanta Android Club?
 

--- a/anti-harrasment-policy.md
+++ b/anti-harrasment-policy.md
@@ -1,11 +1,13 @@
 # Anti-Harassment Policy (template)
 
-Why do we have an official anti-harassment policy for GDG [chapter] / Community Group events?
+Why do we have an official anti-harassment policy for Atlanta Android Club?
 
-It sets expectations for behavior at the event. Simply having an anti-harassment policy can prevent harassment.
+It sets expectations for behavior at any Atlanta Android Club event, on Atlanta 
+Android Club Slack, and in any other Atlanta Android Club related interaction.  
+Simply having an anti-harassment policy can prevent harassment.
 It encourages people to attend who have had bad experiences at other events.
 It gives event staff/volunteers instructions on how to handle harassment quickly, with the minimum amount of disruption for the event.
-GDG [chapter] / Community Group is dedicated to providing a harassment-free event experience for everyone, regardless of:
+Atlanta Android Club is dedicated to providing a harassment-free event experience for everyone, regardless of:
 
 * gender
 * sexual orientation
@@ -16,13 +18,13 @@ GDG [chapter] / Community Group is dedicated to providing a harassment-free even
 * religion
 * nationality
 
-The above is not an exhaustive list -- we do not tolerate harassment of event 
-participants in any form.
+The above is not an exhaustive list -- we do not tolerate harassment of Atlanta 
+Android Club participants in any form.
 
 Sexual language and imagery is not appropriate for any event venue, including 
-talks. Event participants violating these rules may be expelled from the event, 
-and even banned from future events at the discretion of the event 
-organizers/management.
+talks, nor any online interaction. Event participants violating these rules may 
+be expelled from the event and/or Slack, and even banned from future events 
+and/or Slack participation at the discretion of the event organizers/management.
 
 Harassment includes (but is not limited to):
 
@@ -46,20 +48,12 @@ promotional items or demo material.
 
 If you are being harassed, notice that someone else is being harassed, or have 
 any other concerns, please contact an organizer or event volunteer immediately. 
-Organizers and event volunteers may be identified by t-shirts or special 
-badges/lanyards. Organizers will investigate the issue and take appropriate 
+Organizers will investigate the issue and take appropriate 
 action. This may include helping participants contact venue security or local 
 law enforcement, provide escorts, or otherwise assist those experiencing 
 harassment to feel safe for the duration of the event.
 
-Contacts:
-
-[Email address for organizers]
-[Phone number for organizers]
-[Phone number for event security]
-[Local law enforcement]
-[Local emergency and non-emergency medical]
-[Local taxi company]
+The organizers are listed on the [Organizers page](https://www.meetup.com/Atlanta-Android-Club/members/?op=leaders) of the Meetup.com site.
 
 Though we hope that we never have to invoke this policy, we believe that having 
 this document helps everyone think a little more about how their actions and 


### PR DESCRIPTION
* Add anti-harassment policy
* Move Slack-specific content to Slack section
* Generalize code of conduct to cover all events and online forums